### PR TITLE
work around for TypeError while slicing the lists

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,9 +83,11 @@ def build_kdtree(points, depth=0):
     sorted_points = sorted(points, key=lambda point: point[axis])
 
     return {
-        'point': sorted_points[n / 2],
-        'left': build_kdtree(sorted_points[:n / 2], depth + 1),
-        'right': build_kdtree(sorted_points[n/2 + 1:], depth + 1)
+        # TypeError: list indices must be integers or slices, not float 
+        # To make this file compatible with python 3.7.4
+        'point': sorted_points[int(n / 2)],
+        'left': build_kdtree(sorted_points[:int(n / 2)], depth + 1),
+        'right': build_kdtree(sorted_points[int(n / 2 + 1):], depth + 1)
     }
 
 

--- a/main.py
+++ b/main.py
@@ -85,9 +85,9 @@ def build_kdtree(points, depth=0):
     return {
         # TypeError: list indices must be integers or slices, not float 
         # To make this file compatible with python 3.7.4
-        'point': sorted_points[int(n / 2)],
-        'left': build_kdtree(sorted_points[:int(n / 2)], depth + 1),
-        'right': build_kdtree(sorted_points[int(n / 2 + 1):], depth + 1)
+        'point': sorted_points[int(round(n / 2))],  # Splitting Point
+        'left': build_kdtree(sorted_points[:int(round(n / 2))], depth + 1),  # Point before Splitting Point
+        'right': build_kdtree(sorted_points[int(round(n / 2 + 1)):], depth + 1)  # Point after Splitting Point
     }
 
 

--- a/main.py
+++ b/main.py
@@ -85,9 +85,9 @@ def build_kdtree(points, depth=0):
     return {
         # TypeError: list indices must be integers or slices, not float 
         # To make this file compatible with python 3.7.4
-        'point': sorted_points[int(round(n / 2))],  # Splitting Point
-        'left': build_kdtree(sorted_points[:int(round(n / 2))], depth + 1),  # Point before Splitting Point
-        'right': build_kdtree(sorted_points[int(round(n / 2 + 1)):], depth + 1)  # Point after Splitting Point
+        'point': sorted_points[n // 2],  # Splitting Point
+        'left': build_kdtree(sorted_points[:n // 2], depth + 1),  
+        'right': build_kdtree(sorted_points[n // 2 + 1:], depth + 1)  
     }
 
 


### PR DESCRIPTION
To make this file compatible with python 3.7.4 we need to remove TypeError: list indices must be integers or slices, not float